### PR TITLE
#22/ useFetch 와 blogApi 코드에서 skip 과 limit 값 받아 요청하도록 수정

### DIFF
--- a/src/api/blogApi.ts
+++ b/src/api/blogApi.ts
@@ -2,12 +2,18 @@ import { httpClient } from '../utils/httpClient';
 import { BlogListResp, BlogPostResp } from '../types/types';
 
 export const blogApi = {
-  async getBlogList() {
+  async getBlogList(pageInfo: [string, number, number]) {
+    const [method, pageNumber, pageSize] = pageInfo;
+
+    const skip = (pageNumber - 1) * pageSize;
+    const limit = pageSize;
+
     const payload = JSON.stringify({
       collection: 'posts',
       database: 'sample_training',
       dataSource: 'Cluster0',
-      limit: 10,
+      skip,
+      limit,
     });
 
     try {

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,9 +1,9 @@
 import useSWR from 'swr';
 import { blogApi } from '../api/blogApi';
 
-export const useFetch = (method: string) => {
+export const useFetch = (method: string, pageNumber: number = 1, pageSize: number = 10) => {
   const fetcher = blogApi[method];
-  const { data, error, mutate } = useSWR(method, fetcher);
+  const { data, error, mutate } = useSWR([method, pageNumber, pageSize], fetcher);
 
   return {
     data,

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -8,7 +8,7 @@ import { useFetch } from '../hooks/useFetch';
 import { BlogPostResp } from '../types/types';
 
 export const MainPage = () => {
-  const { data: blogList, isLoading, isError } = useFetch('getBlogList');
+  const { data: blogList, isLoading, isError } = useFetch('getBlogList', 1, 3);
 
   return (
     <main>
@@ -30,9 +30,7 @@ export const MainPage = () => {
 
           {isLoading && <LoadingSpinner />}
           {blogList &&
-            blogList
-              .slice(0, 3)
-              .map((blogItem: BlogPostResp) => <PostListItem key={blogItem._id} blogItem={blogItem} />)}
+            blogList.map((blogItem: BlogPostResp) => <PostListItem key={blogItem._id} blogItem={blogItem} />)}
         </div>
       </div>
       <Footer />


### PR DESCRIPTION
### PR TITLE

#22 useFetch 와 blogApi 코드에서 skip 과 limit 값 받아 요청하도록 수정

### DESCRIPTION

* mongoDB 에서는 limit 과 skip 값을 토대로 페이지네이션 구현이 가능함
* 이를 위해 블로그 리스트 데이터 가져오는 코드에서 pageNumber 와 pageSize 받아오도록 수정
* 기본 값은 pageNumber = 1, pageSize = 10 으로 설정
