### PR TITLE
#49/ 코멘트 페이지에 로딩 스피너 적용하기

### DIFF
--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -2,15 +2,21 @@ import { useEffect, useState } from 'react';
 import { CommentResp } from '../types/types';
 import CommentItem from './CommentItem';
 import Pagination from './Pagination';
+import LoadingSpinner from './LoadingSpinner';
 
 type CommentListProp = {
   comments: CommentResp[];
 };
 
 const CommentList = ({ comments }: CommentListProp) => {
+  // 페이지네이션 관련 상태
   const [pageIndex, setPageIndex] = useState(1);
   const [paginationArray, setPaginationArray] = useState([]);
 
+  // 로딩 관련 상태
+  const [loading, setLoading] = useState(true);
+
+  // comment 를 5개씩 분할
   useEffect(() => {
     const newPaginationArray = [];
 
@@ -21,12 +27,29 @@ const CommentList = ({ comments }: CommentListProp) => {
     setPaginationArray(newPaginationArray);
   }, [comments]);
 
+  // 페이지 이동 후 0.5초 동안 로딩 스피너 동작
+  useEffect(() => {
+    setLoading(true);
+    const timer = setTimeout(() => {
+      setLoading(false);
+    }, 500);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [pageIndex]);
+
   return (
     <article className="py-10 border-b border-grey-lighter space-y-6 ">
       <h2 className="text-xl font-bold text-green">Comments</h2>
-      {paginationArray[pageIndex - 1]?.map((comment: CommentResp) => (
-        <CommentItem key={comment.email} />
-      ))}
+
+      {paginationArray[pageIndex - 1] && !loading ? (
+        paginationArray[pageIndex - 1].map((comment: CommentResp) => <CommentItem key={comment.email} />)
+      ) : (
+        <div className="h-96 flex items-center justify-center">
+          <LoadingSpinner />
+        </div>
+      )}
 
       <Pagination totalPage={Math.floor(comments.length / 5)} pageIndex={pageIndex} setPageIndex={setPageIndex} />
     </article>


### PR DESCRIPTION
### PR TITLE

#49 코멘트 페이지에 로딩 스피너 적용하기

### DESCRIPTION
![sakak-0402-6](https://user-images.githubusercontent.com/89173923/229405194-3478a2c9-558c-413c-a027-7884b1452784.gif)
* 페이지 넘길 때마다 0.5 초 텀 두고 로딩 스피너 돌아가도록 구현
* 페이지 넘김 동작을 명확하게 확인하기 위해 추가함
